### PR TITLE
Support activemodel up to 5.1.x

### DIFF
--- a/inflorm.gemspec
+++ b/inflorm.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_dependency "activemodel", ">= 4.2", "<= 5.0"
+  spec.add_dependency "activemodel", ">= 4.2", "< 5.2"
   spec.add_dependency "virtus", "~> 1.0"
 end


### PR DESCRIPTION
Previously we were capped at 5.0.0; support patch versions in the 5.0 line as well as the 5.1 line.